### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inspired by Creativedash's Dribbble post [here](http://dribbble.com/shots/163159
 <p><a href="url"><img src="https://s3.amazonaws.com/f.cl.ly/items/1p0w3B0E3m2I2k3e0z1Q/onoff.gif" align="left" height="150" width="200" ></a></p>
 <br><br><br><br><br><br><br>
 
-##Requirements
+## Requirements
 - iOS 8.0+
 - Xcode 8.0+ (Use pod version 0.0.4 for Xcode 7)
 - Swift 3.0+ (Use pod version 0.0.4 for Swift 2.3)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
